### PR TITLE
Fixes string instead of bool used as arg value

### DIFF
--- a/additionalTypeDefs/user.graphqls
+++ b/additionalTypeDefs/user.graphqls
@@ -19,7 +19,7 @@ extend type UserInfo {
     requiredSelectionSet: "{ id }",
     sourceArgs: {
       userId: "{root.id}",
-      availabilityFilter: "true"
+      availabilityFilter: true
     }
   )
 
@@ -30,7 +30,7 @@ extend type UserInfo {
     requiredSelectionSet: "{ id }",
     sourceArgs: {
       userId: "{root.id}",
-      availabilityFilter: "false"
+      availabilityFilter: false
     }
   )
 


### PR DESCRIPTION
Wasn't an issue before; probably caused by new GraphQL Mesh version
