### PR TITLE
Segment linking

### DIFF
--- a/additionalTypeDefs/content.graphqls
+++ b/additionalTypeDefs/content.graphqls
@@ -19,6 +19,16 @@ extend type MediaContent {
     keyField: "id",
     keysArg: "contentIds"
   )
+
+  segmentLinks: [MediaRecordSegmentLink!]! @resolveTo(
+    sourceName: "DocprocaiService",
+    sourceTypeName: "Query",
+    sourceFieldName: "_internal_noauth_getMediaRecordLinksForContent",
+    requiredSelectionSet: "{ id }",
+    sourceArgs: {
+      contentId: "{root.id}"
+    }
+  )
 }
 
 extend type FlashcardSetAssessment {

--- a/additionalTypeDefs/media.graphqls
+++ b/additionalTypeDefs/media.graphqls
@@ -2,7 +2,7 @@ extend type Query {
     semanticSearch(queryText: String!, count: Int! = 10): [SemanticSearchResult!]! # resolved in media.ts
 }
 
-extend type SemanticSearchDocumentResult {
+extend type DocumentRecordSegment {
     mediaRecord: MediaRecord! @resolveTo(
       sourceName: "MediaService",
       sourceTypeName: "Query",
@@ -12,7 +12,7 @@ extend type SemanticSearchDocumentResult {
     )
 }
 
-extend type SemanticSearchVideoResult {
+extend type VideoRecordSegment {
     mediaRecord: MediaRecord! @resolveTo(
       sourceName: "MediaService",
       sourceTypeName: "Query",
@@ -20,4 +20,20 @@ extend type SemanticSearchVideoResult {
       keyField: "mediaRecordId",
       keysArg: "ids"
     )
+}
+
+extend type MediaRecord {
+  """
+  Returns the contents this media record is linked to. If the user does not have access to a particular
+  content, null will be returned in its place.
+  """
+  contents: [Content]! @resolveTo(
+    sourceName: "ContentService",
+    sourceTypeName: "Query",
+    sourceFieldName: "findContentsByIds",
+    requiredSelectionSet: "{ contentIds }",
+    sourceArgs: {
+      ids: "{root.contentIds}"
+    }
+  )
 }


### PR DESCRIPTION
* Add field segmentLinks to MediaContent, which returns all linked segments of the MediaRecords this MediaContent consists of
* Rename MediaRecord segment types from SemanticSearch... to more generic name (because they are now also used for the linking as explained above)
* Adds the contents field to the MediaRecord type, which returns the contents this MediaRecord is part of (or null if the user is not allowed to see the content)