### PR TITLE
Fix getSemanticallySimilarEntities

### DIFF
--- a/additionalResolvers/content.ts
+++ b/additionalResolvers/content.ts
@@ -262,7 +262,7 @@ const resolvers: Resolvers = {
                 return context.DocprocaiService.Query._internal_noauth_getSemanticallySimilarEntities({
                     root,
                     args: {
-                        segmentId: args.mediaRecordSegmentId,
+                        segmentId: args.segmentId,
                         count: args.count,
                         contentWhitelist: contentWhitelist,
                         excludeEntitiesWithSameParent: args.excludeEntitiesWithSameParent

--- a/additionalTypeDefs/content.graphqls
+++ b/additionalTypeDefs/content.graphqls
@@ -10,7 +10,7 @@ extend type Query {
   Returns at most `count` results. If `excludeEntitiesWithSameParent` is true, segments from the same entity as the
   specified segment will be excluded from the results.
   """
-  getSemanticallySimilarEntities(entityId: UUID!, 
+  getSemanticallySimilarEntities(segmentId: UUID!, 
                                  count: Int! = 10, 
                                  excludeEntitiesWithSameParent: Boolean,
                                  courseWhitelist: [UUID!]): [SemanticSearchResult!]! # resolved in content.ts


### PR DESCRIPTION
Fixes the getSemanticallySimilarEntities query trying to use an old parameter name which leads to parameter not being passed to backend