### PR TITLE
Add summary field to MediaRecord type

### DIFF
--- a/additionalTypeDefs/media.graphqls
+++ b/additionalTypeDefs/media.graphqls
@@ -89,4 +89,19 @@ extend type MediaRecord {
       mediaRecord: "{root.id}"
     }
   )
+
+  """
+  Gets a short summary/overview of the contents of the media record. Returns a list of strings,
+  where each string can be treated as a paragraph.
+  If no summary is available, returns an empty list.
+  """
+  summary: [String!]! @resolveTo(
+    sourceName: "DocprocaiService",
+    sourceTypeName: "Query",
+    sourceFieldName: "_internal_noauth_getMediaRecordSummary",
+    requiredSelectionSet: "{ id }",
+    sourceArgs: {
+      mediaRecordId: "{root.id}"
+    }
+  )
 }


### PR DESCRIPTION
Adds the `summary` field to the `MediaRecord` type, which is fetched from the DocProcAI service