### PR TITLE
fix: enable exposure of `host.docker.local` on Linux machines

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,7 @@ services:
       QUIZ_SERVICE_URL: http://app-quiz:9001/graphql
       DOCPROCAI_SERVICE_URL: http://app-docprocai:9901/graphql/
       DEBUG: 0
+    extra_hosts:
+      # Required for Docker on Linux to resolve host.docker.internal to machine's localhost
+      # Source: https://stackoverflow.com/a/24326540
+      - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Description of changes

When trying to run a backend service locally, one has to substitute the `<service-name>-app` with the docker `host.docker.internal` DNS entry which is routed to the host machines IP/`localhost`. There, the services to be run locally can expose the appropriate ports to establish a connection to the docker containers running in their docker network.
  
## How has this been tested?
Documented on stack overflow & works on my Linux machine with e.g. the `course_service` running locally :)

- [ ] automated unit test
- [ ] automated integration test
- [ ] automated acceptance test
- [x] manual, exploratory test
    
## Checklist before requesting a review
- [x] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My code fulfills all acceptance criteria
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation
- [ ] I have added explanation of architectural decision and rationales to [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [ ] I have updated the changes in the ticket description

## Checklist for reviewer
- [ ] The code works and does not throw errors
- [ ] The code is easy to understand and there are no confusing parts
- [ ] The code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] The code change accomplishes what it is supposed to do
- [ ] I cannot think of any use case in which the code does not behave as intended
- [ ] The added and existing tests reasonably cover the code change
- [ ] I cannot think of any test cases, input or edge cases that should be tested in addition
- [ ] Description of the change is included in the documentation
