### PR TITLE
docker-compose.yml: Fix quiz service url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       FLASHCARD_SERVICE_URL: http://app-flashcard:6001/graphql
       REWARD_SERVICE_URL: http://app-reward:7001/graphql
       SKILLLEVEL_SERVICE_URL: http://app-skilllevel:8001/graphql
-      QUIZ_SERVICE_URL: http://host.docker.internal:9001/graphql
+      QUIZ_SERVICE_URL: http://app-quiz:9001/graphql
       DOCPROCAI_SERVICE_URL: http://app-docprocai:9901/graphql/
       DEBUG: 0
       ENABLE_LOGGING: 1 # Set to 1 to enable custom logging


### PR DESCRIPTION
host.docker.internal only works on Windows (and Linux with the already applied workaround). To support MacOS, we use the docker container name in the url